### PR TITLE
Fix default foldout state in UnityEventFoldoutDrawer

### DIFF
--- a/Editor/UnityEventFoldoutDrawer.cs
+++ b/Editor/UnityEventFoldoutDrawer.cs
@@ -12,7 +12,7 @@ namespace Plugins
         {
             string key = "UnityEventFoldout_" + property.propertyPath + "_" + property.serializedObject.targetObject.GetInstanceID();
 
-            bool foldout = EditorPrefs.GetBool(key, true);
+            bool foldout = EditorPrefs.HasKey(key) ? EditorPrefs.GetBool(key) : false;
 
             bool newFoldout = EditorGUI.Foldout(
                 new Rect(position.x, position.y, position.width, EditorGUIUtility.singleLineHeight),
@@ -38,7 +38,7 @@ namespace Plugins
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
         {
             string key = "UnityEventFoldout_" + property.propertyPath + "_" + property.serializedObject.targetObject.GetInstanceID();
-            bool foldout = EditorPrefs.GetBool(key, true);
+            bool foldout = EditorPrefs.HasKey(key) ? EditorPrefs.GetBool(key) : false;
 
             if (foldout)
                 return EditorGUI.GetPropertyHeight(property, true) + EditorGUIUtility.singleLineHeight + 2;


### PR DESCRIPTION
Changed the default foldout state to false if no EditorPrefs key exists, instead of defaulting to true. This ensures foldouts are collapsed by default unless previously expanded by the user.